### PR TITLE
Rewrite to /bin/sh, add --config option

### DIFF
--- a/magit.sh
+++ b/magit.sh
@@ -31,7 +31,7 @@
 
 # * Code:
 
-dependencies=(magit async dash with-editor git-commit transient)
+dependencies=(magit magit-section async dash with-editor git-commit transient)
 
 function load_paths {
     # Echo the "-L PATH" arguments for Emacs.  Since multiple versions

--- a/magit.sh
+++ b/magit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (C) 2020  Adam Porter
 


### PR DESCRIPTION
This does a few things, but I thought it would be cleaner to do this
than to clutter things up with different PRs.  It is a bit of a mix
between cleanup and features, though the commits are reasonably atomic
at least.

Overview:

- Add magit-section to dependencies

  This is needed on some systems ever since the magit v3 release.  If
  this is not present, magit.sh will error out saying that it can't find
  the magit-section package.

- Rewrite magit.sh to use /bin/sh

  This increases portability of the script and makes it effortlessly
  available even on systems that do not have a /bin/bash.  It does add a
  dependency on sed in order to recreate `printf '%q'` but, given the
  nature of the arguments, that may well be removed—printf '%s' is just
  fine in our case.

  Fixes: https://github.com/alphapapa/magit.sh/issues/2

- Shift inside argument case statement

  Instead of shifting outside of the case and always looping, actually
  check if there is something to loop over.  This allows one to have
  much more freedom with regards to options with different arguments.

- Add -c/--config option

  This option allows for configuring the Emacs configuration path; i.e.,
  the path that we look for when it comes to sourcing packages.